### PR TITLE
Enable CPU Type on machine template

### DIFF
--- a/api/v1beta1/type.go
+++ b/api/v1beta1/type.go
@@ -68,8 +68,8 @@ type Hardware struct {
 	// +kubebuilder:default:=2
 	CPU int `json:"cpu,omitempty"`
 
-	// emulated cpu type
-	// CPUType string `json:"cpuType,omitempty"`
+	// Emulated CPU Type. Defaults to kvm64
+	CPUType string `json:"cpuType,omitempty"`
 
 	// +kubebuilder:validation:Minimum:=1
 	// The number of CPU sockets. Defaults to 1.

--- a/cloud/services/compute/instance/qemu.go
+++ b/cloud/services/compute/instance/qemu.go
@@ -105,6 +105,7 @@ func (s *Service) generateVMOptions() api.VirtualMachineCreateOptions {
 		Boot:          fmt.Sprintf("order=%s", bootDvice),
 		CiCustom:      cicustom,
 		Cores:         hardware.CPU,
+		Cpu:           hardware.CPUType,
 		CpuLimit:      hardware.CPULimit,
 		Description:   options.Description,
 		HugePages:     options.HugePages.String(),

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -247,6 +247,9 @@ spec:
                       Defaults to 0.
                     minimum: 0
                     type: integer
+                  cpuType:
+                    description: Emulated CPU Type. Defaults to kvm64
+                    type: string
                   disk:
                     default: 50G
                     description: hard disk size

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -264,6 +264,9 @@ spec:
                               no CPU limit. Defaults to 0.
                             minimum: 0
                             type: integer
+                          cpuType:
+                            description: Emulated CPU Type. Defaults to kvm64
+                            type: string
                           disk:
                             default: 50G
                             description: hard disk size


### PR DESCRIPTION
Hi!

Please let me know if there is anything I missed in this change.

I'm trying to deploy a pod to a cluster managed with this provider, but it seems to have an issue where the image is incompatible with the `kvm64` cpu type as there are features missing (eg SSE4.2)