### PR TITLE
Upgrade proxmox-go to include pve8 memory changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.3.0
 	github.com/imdario/mergo v0.3.13
-	github.com/k8s-proxmox/proxmox-go v0.0.0-alpha25
+	github.com/k8s-proxmox/proxmox-go v0.0.0-alpha28
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k8s-proxmox/proxmox-go v0.0.0-alpha25 h1:vPkQUj+1ZsJNhxFktsWB9+efgGIWJ8VmgSgq9OJKxPI=
 github.com/k8s-proxmox/proxmox-go v0.0.0-alpha25/go.mod h1:ZSAdc9vVAEcIhbNkZxURWTY+k59cXUy9mswp5ofMM40=
+github.com/k8s-proxmox/proxmox-go v0.0.0-alpha28 h1:h0PwVITcljicpXCmMcOyXeXWhkVeYBiK4F2A/Ch5dxg=
+github.com/k8s-proxmox/proxmox-go v0.0.0-alpha28/go.mod h1:ZSAdc9vVAEcIhbNkZxURWTY+k59cXUy9mswp5ofMM40=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
@sp-yduck, including the new version of proxmox-go as referenced here: https://github.com/k8s-proxmox/proxmox-go/pull/11